### PR TITLE
Added missing maven repo for restlet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,14 @@
 	<packaging>pom</packaging>
 	<name>uReplicator</name>
 
+	<repositories>
+		<repository>
+			<id>maven-restlet</id>
+			<name>Public online Restlet repository</name>
+			<url>http://maven.restlet.org</url>
+		</repository>
+	</repositories>
+	
 	<modules>
 		<module>uReplicator-Controller</module>
 		<module>uReplicator-Worker</module>

--- a/uReplicator-Controller/pom.xml
+++ b/uReplicator-Controller/pom.xml
@@ -260,7 +260,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.6-SNAPSHOT</version>
+                <version>0.7.9</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>


### PR DESCRIPTION
It seems "org.restlet" maven artifacts are not available in the public maven repo. 

Adding : - 

```
	<repositories>
		<repository>
			<id>maven-restlet</id>
			<name>Public online Restlet repository</name>
			<url>http://maven.restlet.org</url>
		</repository>
	</repositories>
```

fixed the maven build.
