### PR TITLE
Fix CompactConsumerFetcherThread die silently

### DIFF
--- a/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherManager.scala
+++ b/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherManager.scala
@@ -204,7 +204,7 @@ class CompactConsumerFetcherManager(private val consumerIdString: String,
   }
 
   def addPartitionsWithError(partitionList: Iterable[TopicAndPartition]) {
-    debug("adding partitions with error %s".format(partitionList))
+    info("adding partitions with error %s".format(partitionList))
     if (partitionNewLeaderMap != null) {
       inLock(updateMapLock) {
         partitionList.foreach(p => partitionNewLeaderMap.put(p, true))

--- a/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherThread.scala
+++ b/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherThread.scala
@@ -174,9 +174,10 @@ class CompactConsumerFetcherThread(name: String,
 
         partitionMap.foreach {
           case ((topicAndPartition, partitionFetchState)) =>
-            if (partitionFetchState.isActive)
+            if (partitionFetchState.isActive) {
               fetchRequestBuilder.addFetch(topicAndPartition.topic, topicAndPartition.partition,
                 partitionFetchState.offset, fetchSize)
+            }
         }
 
         fetchRequest = fetchRequestBuilder.build()

--- a/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherThread.scala
+++ b/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherThread.scala
@@ -142,52 +142,62 @@ class CompactConsumerFetcherThread(name: String,
   }
 
   override def doWork() {
-    var fetchRequest: FetchRequest = null
+    try {
+      var fetchRequest: FetchRequest = null
 
-    inLock(partitionMapLock) {
-      inLock(updateMapLock) {
-        // add topic partition into partitionMap
-        val addIter = partitionAddMap.entrySet().iterator()
-        while (addIter.hasNext) {
-          val tpToAdd = addIter.next()
-          if (!partitionMap.contains(tpToAdd.getKey)) {
-            partitionMap.put(tpToAdd.getKey, tpToAdd.getValue)
+      inLock(partitionMapLock) {
+        inLock(updateMapLock) {
+          // add topic partition into partitionMap
+          val addIter = partitionAddMap.entrySet().iterator()
+          while (addIter.hasNext) {
+            val tpToAdd = addIter.next()
+            if (!partitionMap.contains(tpToAdd.getKey)) {
+              partitionMap.put(tpToAdd.getKey, tpToAdd.getValue)
+            }
           }
+          partitionAddMap.clear()
+
+          // remove topic partition from partitionMap
+          val deleteIter = partitionDeleteMap.entrySet().iterator()
+          while (deleteIter.hasNext) {
+            val tpToDelete = deleteIter.next()
+            if (partitionMap.contains(tpToDelete.getKey)) {
+              partitionMap.remove(tpToDelete.getKey)
+            }
+            val lagMetricToRemove = new ClientIdTopicPartition(clientId, tpToDelete.getKey.topic, tpToDelete.getKey.partition)
+            if (fetcherLagStats.stats.contains(lagMetricToRemove)) {
+              fetcherLagStats.stats.remove(lagMetricToRemove)
+            }
+          }
+          partitionDeleteMap.clear()
         }
-        partitionAddMap.clear()
 
-        // remove topic partition from partitionMap
-        val deleteIter = partitionDeleteMap.entrySet().iterator()
-        while (deleteIter.hasNext) {
-          val tpToDelete = deleteIter.next()
-          if (partitionMap.contains(tpToDelete.getKey)) {
-            partitionMap.remove(tpToDelete.getKey)
-          }
-          val lagMetricToRemove = new ClientIdTopicPartition(clientId, tpToDelete.getKey.topic, tpToDelete.getKey.partition)
-          if (fetcherLagStats.stats.contains(lagMetricToRemove)) {
-            fetcherLagStats.stats.remove(lagMetricToRemove)
-          }
+        partitionMap.foreach {
+          case ((topicAndPartition, partitionFetchState)) =>
+            if (partitionFetchState.isActive)
+              fetchRequestBuilder.addFetch(topicAndPartition.topic, topicAndPartition.partition,
+                partitionFetchState.offset, fetchSize)
         }
-        partitionDeleteMap.clear()
+
+        fetchRequest = fetchRequestBuilder.build()
+        if (fetchRequest.requestInfo.isEmpty) {
+          trace("There are no active partitions. Back off for %d ms before sending a fetch request".format(fetchBackOffMs))
+          partitionMapCond.await(fetchBackOffMs, TimeUnit.MILLISECONDS)
+        }
+        logTopicPartitionInfo()
       }
 
-      partitionMap.foreach {
-        case ((topicAndPartition, partitionFetchState)) =>
-          if (partitionFetchState.isActive)
-            fetchRequestBuilder.addFetch(topicAndPartition.topic, topicAndPartition.partition,
-              partitionFetchState.offset, fetchSize)
+      if (!fetchRequest.requestInfo.isEmpty) {
+        processFetchRequest(fetchRequest)
       }
-
-      fetchRequest = fetchRequestBuilder.build()
-      if (fetchRequest.requestInfo.isEmpty) {
-        trace("There are no active partitions. Back off for %d ms before sending a fetch request".format(fetchBackOffMs))
-        partitionMapCond.await(fetchBackOffMs, TimeUnit.MILLISECONDS)
-      }
-      logTopicPartitionInfo()
+    } catch {
+      case e: InterruptedException =>
+        throw e
+      case e: Throwable =>
+        if (isRunning.get()) {
+          error("Error due to ", e)
+        }
     }
-
-    if (!fetchRequest.requestInfo.isEmpty)
-      processFetchRequest(fetchRequest)
   }
 
   private def processFetchRequest(fetchRequest: FetchRequest) {


### PR DESCRIPTION
CompactConsumerFetcherThread will die if there is any consumer exception and CompactConsumerFetcherManager is not able to re-create the thread since the reference is still there.

This is also observed in https://github.com/uber/uReplicator/issues/29