### PR TITLE
Fix duplication; Remove from partitionNewLeaderMap when deleting topics

### DIFF
--- a/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherManager.scala
+++ b/uReplicator-Worker/src/main/scala/kafka/mirrormaker/CompactConsumerFetcherManager.scala
@@ -204,7 +204,7 @@ class CompactConsumerFetcherManager(private val consumerIdString: String,
   }
 
   def addPartitionsWithError(partitionList: Iterable[TopicAndPartition]) {
-    debug("adding partitions with error %s".format(partitionList))
+    info("adding partitions with error %s".format(partitionList))
     if (partitionNewLeaderMap != null) {
       inLock(updateMapLock) {
         partitionList.foreach(p => partitionNewLeaderMap.put(p, true))
@@ -279,6 +279,9 @@ class CompactConsumerFetcherManager(private val consumerIdString: String,
           }
           if (noLeaderPartitionSet.contains(tpToDelete.getKey)) {
             noLeaderPartitionSet.remove(tpToDelete.getKey)
+          }
+          if (partitionNewLeaderMap.containsKey(tpToDelete.getKey)) {
+            partitionNewLeaderMap.remove(tpToDelete.getKey)
           }
         }
         partitionDeleteMap.clear()

--- a/uReplicator-Worker/src/main/scala/kafka/mirrormaker/KafkaConnector.scala
+++ b/uReplicator-Worker/src/main/scala/kafka/mirrormaker/KafkaConnector.scala
@@ -26,7 +26,6 @@ import kafka.utils.{Pool, ZKGroupTopicDirs, ZkUtils}
 import org.I0Itec.zkclient.ZkClient
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 /**
  * This class handles the consumers interaction with zookeeper
@@ -43,7 +42,6 @@ class KafkaConnector(private val consumerIdString: String,
   private val fetcherManager: CompactConsumerFetcherManager = new CompactConsumerFetcherManager(consumerIdString, config, zkClient)
   private val zkUtils = ZkUtils.apply(zkClient, false)
   private val cluster = zkUtils.getCluster()
-  private var allPartitionInfos = new mutable.MutableList[PartitionTopicInfo]()
 
   // Using a concurrent hash map for efficiency. Without this we will need a lock
   val topicRegistry = new ConcurrentHashMap[TopicAndPartition, PartitionTopicInfo]()
@@ -87,7 +85,7 @@ class KafkaConnector(private val consumerIdString: String,
     }
 
     val offsets = fetchOffsetFromZooKeeper(TopicAndPartition(topic, partition))
-    var offset = offsets._2.offset
+    val offset = offsets._2.offset
     info("Fetched offset : %d, for topic: %s , partition %d".format(offset, topic, partition))
     val consumedOffset = new AtomicLong(offset)
     val fetchedOffset = new AtomicLong(offset)


### PR DESCRIPTION
When deleting a topic, need to remove from partitionNewLeaderMap as well. Otherwise, it will be add back if it is in partitionNewLeaderMap.