### PR TITLE
Use max traffic during the last day as estimated workload

### DIFF
--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/AutoRebalanceLiveInstanceChangeListener.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/AutoRebalanceLiveInstanceChangeListener.java
@@ -104,7 +104,9 @@ public class AutoRebalanceLiveInstanceChangeListener implements LiveInstanceChan
             @Override
             public void run() {
               try {
-                rebalanceCurrentCluster(_helixMirrorMakerManager.getCurrentLiveInstances(), false);
+                if (_helixMirrorMakerManager.getWorkloadInfoRetriever().isInitialized()) {
+                  rebalanceCurrentCluster(_helixMirrorMakerManager.getCurrentLiveInstances(), false);
+                }
               } catch (Exception e) {
                 LOGGER.error("Got exception during periodically rebalancing the whole cluster! ", e);
               }

--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/OffsetMonitor.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/OffsetMonitor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -107,7 +108,9 @@ public class OffsetMonitor {
 
   public void start() {
     if (refreshIntervalInSec > 0) {
-      logger.info("OffsetMonitor starts updating offsets every {} seconds", refreshIntervalInSec);
+      // delay for 1-5 minutes
+      int delaySec = 60 + new Random().nextInt(240);
+      logger.info("OffsetMonitor starts updating offsets every {} seconds with delay {} seconds", refreshIntervalInSec, delaySec);
       logger.info("OffsetMonitor starts with brokerList=" + srcBrokerList);
 
       refreshExecutor.scheduleAtFixedRate(new Runnable() {
@@ -117,7 +120,7 @@ public class OffsetMonitor {
           updateTopicList();
           updateOffset();
         }
-      }, 130, refreshIntervalInSec, TimeUnit.SECONDS);
+      }, delaySec, refreshIntervalInSec, TimeUnit.SECONDS);
     } else {
       logger.info("OffsetMonitor is disabled");
     }


### PR DESCRIPTION
To stablize the workload balancing, we use the max traffic window in the last day as estimated workload for a topic. To increase the response time for traffic spike, we decrease the traffic window from 1 hour to 10 minutes.