### PR TITLE
Fix concurrency issue when registering metrics

### DIFF
--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/OffsetMonitor.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/OffsetMonitor.java
@@ -299,7 +299,7 @@ public class OffsetMonitor {
     return "OffsetMonitorLag." + tp.topic().replace('.', '_') + "." + tp.partition();
   }
 
-  private void updateOffsetMetrics() {
+  private synchronized void updateOffsetMetrics() {
     MetricRegistry metricRegistry = HelixKafkaMirrorMakerMetricsReporter.get().getRegistry();
     @SuppressWarnings("rawtypes")
     Map<String, Gauge> gauges = metricRegistry.getGauges();


### PR DESCRIPTION
Fix the concurrency issue when registering lag metric for each topic partition.