### PR TITLE
Treat offset 0 as initial status

### DIFF
--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/AutoRebalanceLiveInstanceChangeListener.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/AutoRebalanceLiveInstanceChangeListener.java
@@ -648,7 +648,7 @@ public class AutoRebalanceLiveInstanceChangeListener implements LiveInstanceChan
    */
   private long getLagTime(TopicPartition tp) {
     TopicPartitionLag tpl = _helixMirrorMakerManager.getOffsetMonitor().getTopicPartitionOffset(tp);
-    if (tpl == null || tpl.getLatestOffset() < 0 || tpl.getCommitOffset() < 0
+    if (tpl == null || tpl.getLatestOffset() <= 0 || tpl.getCommitOffset() <= 0
         || System.currentTimeMillis() - tpl.getTimeStamp() > _offsetMaxValidTimeMillis) {
       return 0;
     }

--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/OffsetMonitor.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/OffsetMonitor.java
@@ -327,7 +327,7 @@ public class OffsetMonitor {
           @Override
           public Long getValue() {
             TopicPartitionLag lag = topicPartitionToOffsetMap.get(topicPartition);
-            if (lag == null || lag.getLatestOffset() < 0 || lag.getCommitOffset() < 0
+            if (lag == null || lag.getLatestOffset() <= 0 || lag.getCommitOffset() <= 0
                 || lag.getLatestOffset() <= lag.getCommitOffset()) {
               return 0L;
             }
@@ -368,7 +368,7 @@ public class OffsetMonitor {
     List<TopicAndPartition> tps = new ArrayList<>();
     for (Map.Entry<TopicAndPartition, TopicPartitionLag> entry : noProgressMap.entrySet()) {
       TopicPartitionLag currentLag = topicPartitionToOffsetMap.get(entry.getKey());
-      if (currentLag == null || currentLag.getCommitOffset() < 0 || currentLag.getLatestOffset() < 0
+      if (currentLag == null || currentLag.getCommitOffset() <= 0 || currentLag.getLatestOffset() <= 0
           || currentLag.getLatestOffset() <= currentLag.getCommitOffset()) {
         continue;
       }


### PR DESCRIPTION
When we whitelist a new topic, we initialize the commit offset as 0, so we should treat 0 as initial status and do not detect lagging or stuck status if it is 0.