### PR TITLE
Provide basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ WORKDIR /usr/src/app
 RUN mvn clean package -DskipTests
 RUN chmod +x /usr/src/app/bin/pkg/*.sh
 
-ENTRYPOINT [ "./uReplicator-Distribution/target/uReplicator-Distribution-pkg/bin/start-controller.sh" ]
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "controller" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.5-jdk-8
+
+ARG MAVEN_OPTS="-Xmx1024M -Xss128M -XX:MetaspaceSize=512M -XX:MaxMetaspaceSize=1024M -XX:+CMSClassUnloadingEnabled"
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN mvn clean package -DskipTests
+RUN chmod +x /usr/src/app/bin/pkg/*.sh
+
+ENTRYPOINT [ "./uReplicator-Distribution/target/uReplicator-Distribution-pkg/bin/start-controller.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+  controller)
+    exec ./uReplicator-Distribution/target/uReplicator-Distribution-pkg/bin/start-controller.sh ${@:2}
+  ;;
+  worker)
+    exec ./uReplicator-Distribution/target/uReplicator-Distribution-pkg/bin/start-worker.sh ${@:2}
+  ;;
+  *)
+    exec $@
+  ;;
+esac


### PR DESCRIPTION
Example with mvn build through docker.
This allows users to easily start experimenting with no other dependencies than Docker.