### PR TITLE
fix bug. default refreshTimeIntervalInMillis is too big and should get from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ out
 *.ipr
 *.iws
 *.iml
+bin/pkg/**

--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/ControllerStarter.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/ControllerStarter.java
@@ -83,7 +83,7 @@ public class ControllerStarter {
     if (_config.getEnableSrcKafkaValidation()) {
       if (!_kafkaBrokerTopicObserverMap.containsKey(SRC_KAFKA_CLUSTER)) {
         _kafkaBrokerTopicObserverMap.put(SRC_KAFKA_CLUSTER,
-            new KafkaBrokerTopicObserver(SRC_KAFKA_CLUSTER, _config.getSrcKafkaZkPath()));
+            new KafkaBrokerTopicObserver(SRC_KAFKA_CLUSTER, _config.getSrcKafkaZkPath(), _config.getRefreshTimeInSeconds()));
       }
       return new SourceKafkaClusterValidationManager(
           _kafkaBrokerTopicObserverMap.get(SRC_KAFKA_CLUSTER),
@@ -98,11 +98,11 @@ public class ControllerStarter {
     if (_config.getEnableAutoWhitelist()) {
       if (!_kafkaBrokerTopicObserverMap.containsKey(SRC_KAFKA_CLUSTER)) {
         _kafkaBrokerTopicObserverMap.put(SRC_KAFKA_CLUSTER,
-            new KafkaBrokerTopicObserver(SRC_KAFKA_CLUSTER, _config.getSrcKafkaZkPath()));
+            new KafkaBrokerTopicObserver(SRC_KAFKA_CLUSTER, _config.getSrcKafkaZkPath(), _config.getRefreshTimeInSeconds()));
       }
       if (!_kafkaBrokerTopicObserverMap.containsKey(DEST_KAFKA_CLUSTER)) {
         _kafkaBrokerTopicObserverMap.put(DEST_KAFKA_CLUSTER,
-            new KafkaBrokerTopicObserver(DEST_KAFKA_CLUSTER, _config.getDestKafkaZkPath()));
+            new KafkaBrokerTopicObserver(DEST_KAFKA_CLUSTER, _config.getDestKafkaZkPath(), _config.getRefreshTimeInSeconds()));
       }
 
       String patternToExcludeTopics = _config.getPatternToExcludeTopics();

--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/KafkaBrokerTopicObserver.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/KafkaBrokerTopicObserver.java
@@ -49,7 +49,6 @@ public class KafkaBrokerTopicObserver implements IZkChildListener {
       LoggerFactory.getLogger(KafkaBrokerTopicObserver.class);
 
   private static String KAFKA_TOPICS_PATH = "/brokers/topics";
-  private static long defaultRefreshTimeIntervalInMillis = 5 * 60 * 1000;
 
   private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
@@ -65,10 +64,6 @@ public class KafkaBrokerTopicObserver implements IZkChildListener {
   private final Counter _kafkaTopicsCounter = new Counter();
   private final static String METRIC_TEMPLATE = "KafkaBrokerTopicObserver.%s.%s";
   private final Object _lock = new Object();
-
-  public KafkaBrokerTopicObserver(String brokerClusterName, String zkString) {
-    this(brokerClusterName, zkString, defaultRefreshTimeIntervalInMillis);
-  }
 
   public KafkaBrokerTopicObserver(String brokerClusterName, String zkString, long refreshTimeIntervalInMillis) {
     LOGGER.info("Trying to init KafkaBrokerTopicObserver {} with ZK: {}", brokerClusterName,

--- a/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/KafkaBrokerTopicObserver.java
+++ b/uReplicator-Controller/src/main/java/com/uber/stream/kafka/mirrormaker/controller/core/KafkaBrokerTopicObserver.java
@@ -49,6 +49,8 @@ public class KafkaBrokerTopicObserver implements IZkChildListener {
       LoggerFactory.getLogger(KafkaBrokerTopicObserver.class);
 
   private static String KAFKA_TOPICS_PATH = "/brokers/topics";
+  private static long defaultRefreshTimeIntervalInMillis = 5 * 60 * 1000;
+
   private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
   private final ZkClient _zkClient;
@@ -57,16 +59,22 @@ public class KafkaBrokerTopicObserver implements IZkChildListener {
   private final Map<String, TopicPartition> _topicPartitionInfoMap =
       new ConcurrentHashMap<String, TopicPartition>();
   private final AtomicLong _lastRefreshTime = new AtomicLong(0);
-  private final long _refreshTimeIntervalInMillis = 60 * 60 * 1000;
+
+  private long _refreshTimeIntervalInMillis;
   private final Timer _refreshLatency = new Timer();
   private final Counter _kafkaTopicsCounter = new Counter();
   private final static String METRIC_TEMPLATE = "KafkaBrokerTopicObserver.%s.%s";
   private final Object _lock = new Object();
 
   public KafkaBrokerTopicObserver(String brokerClusterName, String zkString) {
+    this(brokerClusterName, zkString, defaultRefreshTimeIntervalInMillis);
+  }
+
+  public KafkaBrokerTopicObserver(String brokerClusterName, String zkString, long refreshTimeIntervalInMillis) {
     LOGGER.info("Trying to init KafkaBrokerTopicObserver {} with ZK: {}", brokerClusterName,
-        zkString);
+            zkString);
     _kakfaClusterName = brokerClusterName;
+    _refreshTimeIntervalInMillis = refreshTimeIntervalInMillis;
     _zkClient = new ZkClient(zkString, 30000, 30000, ZKStringSerializer$.MODULE$);
     _zkClient.subscribeChildChanges(KAFKA_TOPICS_PATH, this);
     _zkUtils = ZkUtils.apply(_zkClient, false);
@@ -76,7 +84,7 @@ public class KafkaBrokerTopicObserver implements IZkChildListener {
       public void run() {
         tryToRefreshCache();
       }
-    }, 0, 600, TimeUnit.SECONDS);
+    }, 0, _refreshTimeIntervalInMillis, TimeUnit.SECONDS);
   }
 
   private void registerMetric() {

--- a/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/core/TestAutoTopicWhitelistingManager.java
+++ b/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/core/TestAutoTopicWhitelistingManager.java
@@ -49,7 +49,7 @@ public class TestAutoTopicWhitelistingManager {
     } catch (Exception e) {
     }
     kafkaBrokerTopicObserver =
-        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR);
+        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR, 1);
 
     ControllerConf controllerConf = new ControllerConf();
     controllerConf.setControllerPort("9090");

--- a/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/core/TestKafkaBrokerTopicObserver.java
+++ b/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/core/TestKafkaBrokerTopicObserver.java
@@ -48,7 +48,7 @@ public class TestKafkaBrokerTopicObserver {
     } catch (Exception e) {
     }
     kafkaBrokerTopicObserver =
-        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR);
+        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR, 1);
     try {
       Thread.sleep(3000);
     } catch (Exception e) {

--- a/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/rest/ControllerStarterTest.java
+++ b/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/rest/ControllerStarterTest.java
@@ -69,7 +69,7 @@ public class ControllerStarterTest {
     } catch (Exception e) {
     }
     kafkaBrokerTopicObserver =
-        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR);
+        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR, 1);
 
     ZK_CLIENT = new ZkClient(ZkStarter.DEFAULT_ZK_STR);
     ZK_CLIENT.deleteRecursive("/" + HELIX_CLUSTER_NAME);

--- a/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/validation/TestSourceKafkaClusterValidationManager.java
+++ b/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/validation/TestSourceKafkaClusterValidationManager.java
@@ -52,7 +52,7 @@ public class TestSourceKafkaClusterValidationManager {
     } catch (Exception e) {
     }
     kafkaBrokerTopicObserver =
-        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR);
+        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR, 1);
 
     ControllerConf controllerConf = new ControllerConf();
     controllerConf.setControllerPort("9090");

--- a/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/validation/TestValidationManager.java
+++ b/uReplicator-Controller/src/test/java/com/uber/stream/kafka/mirrormaker/controller/validation/TestValidationManager.java
@@ -60,7 +60,7 @@ public class TestValidationManager {
     } catch (Exception e) {
     }
     kafkaBrokerTopicObserver =
-        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR);
+        new KafkaBrokerTopicObserver("broker0", KafkaStarterUtils.DEFAULT_ZK_STR, 1);
 
     ControllerConf controllerConf = new ControllerConf();
     controllerConf.setControllerPort("9090");


### PR DESCRIPTION
I did not use the new constructor now which should get value from config param, I'm not sure if I misunderstood something. Currently,SourceKafkaClusterValidationManager, AutoTopicWhitelistingManagern can not get topics info as soon as it expected. If I'm right, I'd like to add a new param in controllerOptions or use refreshTimeInSeconds for common sense.