### PR TITLE
change lookback to 2 hours

### DIFF
--- a/uReplicator-Common/src/main/java/com/uber/stream/kafka/mirrormaker/common/core/WorkloadInfoRetriever.java
+++ b/uReplicator-Common/src/main/java/com/uber/stream/kafka/mirrormaker/common/core/WorkloadInfoRetriever.java
@@ -59,6 +59,7 @@ public class WorkloadInfoRetriever {
 
   // valid for a day so that it can be adaptive for traffic with day-pattern
   private long _maxValidTimeMillis = TimeUnit.HOURS.toMillis(25);
+  private long _estimationLookbackWindow = TimeUnit.HOURS.toMillis(2);
 
   public WorkloadInfoRetriever(IHelixManager helixMirrorMakerManager) {
     this(helixMirrorMakerManager, helixMirrorMakerManager.getConf().getSrcKafkaZkPath());
@@ -136,7 +137,7 @@ public class WorkloadInfoRetriever {
     TopicWorkload maxTw = null;
     long current = System.currentTimeMillis();
     for (TopicWorkload tw : tws) {
-      if (current - tw.getLastUpdate() > _maxValidTimeMillis) {
+      if (current - tw.getLastUpdate() > _estimationLookbackWindow) {
         continue;
       }
       if (maxTw == null || maxTw.getBytesPerSecond() < tw.getBytesPerSecond()) {

--- a/uReplicator-Common/src/test/java/com/uber/stream/kafka/mirrormaker/common/core/TestWorkloadInfoRetriever.java
+++ b/uReplicator-Common/src/test/java/com/uber/stream/kafka/mirrormaker/common/core/TestWorkloadInfoRetriever.java
@@ -1,0 +1,32 @@
+package com.uber.stream.kafka.mirrormaker.common.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
+
+public class TestWorkloadInfoRetriever {
+    @Test
+    public void testGetTopicWorkload() {
+        WorkloadInfoRetriever retriever = new WorkloadInfoRetriever();
+        LinkedList<TopicWorkload> workloadLst = new LinkedList<>();
+        retriever._topicWorkloadMap.put("trip_created", workloadLst);
+
+        // Case #1 some workload updated within 2 hours
+        TopicWorkload wl = new TopicWorkload(10 * 1024, 10);
+        long currentTime = System.currentTimeMillis();
+        wl.setLastUpdate(currentTime - TimeUnit.HOURS.toMillis(1));
+        workloadLst.add(wl);
+        TopicWorkload oldWorkload =  new TopicWorkload(20 * 1024, 20);
+        oldWorkload.setLastUpdate(currentTime - TimeUnit.HOURS.toMillis(9));
+        workloadLst.add(oldWorkload);
+
+        Assert.assertEquals(retriever.topicWorkload("trip_created").compareTo(wl), 0);
+
+        workloadLst.clear();
+        workloadLst.add(oldWorkload);
+        Assert.assertEquals(retriever.topicWorkload("trip_created").compareTo(oldWorkload), 0);
+
+    }
+}


### PR DESCRIPTION
When querying workload, only look back 2 hours for maximum workload instead of looking back 25 hours.
This will help prevent cases when in the past day there were cases like failover and we over-estimate.