### PR TITLE
url pointing to kafka no longer exists, causing a `bin/grid bootstrap` failure

### DIFF
--- a/bin/grid
+++ b/bin/grid
@@ -34,7 +34,7 @@ DOWNLOAD_CACHE_DIR=$HOME/.kafkamirrormaker/download
 COMMAND=$1
 SYSTEM=$2
 
-DOWNLOAD_KAFKA=http://www.us.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz
+DOWNLOAD_KAFKA=http://www.us.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz
 DOWNLOAD_ZOOKEEPER=http://archive.apache.org/dist/zookeeper/zookeeper-3.4.3/zookeeper-3.4.3.tar.gz
 
 bootstrap() {
@@ -62,7 +62,7 @@ install_zookeeper() {
 
 install_kafka() {
   mkdir -p "$DEPLOY_ROOT_DIR"
-  install kafka $DOWNLOAD_KAFKA kafka_2.11-0.10.2.1
+  install kafka $DOWNLOAD_KAFKA kafka_2.11-0.10.2.2
   # have to use SIGTERM since nohup on appears to ignore SIGINT
   # and Kafka switched to SIGINT in KAFKA-1031.
   sed -i.bak 's/SIGINT/SIGTERM/g' $DEPLOY_ROOT_DIR/kafka/bin/kafka-server-stop.sh


### PR DESCRIPTION
this PR switches the URL to one that does. see http://www.us.apache.org/dist/kafka/