### PR TITLE
Fixed outdated docker images FROM and KAFKA_VERSION

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8
 #
 # Copyright (C) 2015-2017 Uber Technologies, Inc. (streaming-data@uber.com)
 #
@@ -17,7 +17,7 @@ FROM java:openjdk-8-jre
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV SCALA_VERSION 2.11
-ENV KAFKA_VERSION 0.10.2.2
+ENV KAFKA_VERSION 2.3.0
 ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
 ENV DOWNLOAD_ZOOKEEPER http://archive.apache.org/dist/zookeeper/zookeeper-3.4.3/zookeeper-3.4.3.tar.gz
 


### PR DESCRIPTION
Experienced errors when following the documentation from the branch-1.0
`docker` build -t devenv devenv/.`

The build failed because the FROM images was oudate and apt repository were moved to archive.
__Ref: https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository

> Wheezy and Jessie were recently removed from the mirror network, so if you want to continue fetching Jessie backports, you need to use archive.debian.org instead:


Doing a quick research, I found the official openjdk:8 and updated the kafka version to match the download page url.