### PR TITLE
Updated kafka url to new location

### DIFF
--- a/bin/grid
+++ b/bin/grid
@@ -34,7 +34,7 @@ DOWNLOAD_CACHE_DIR=$HOME/.kafkamirrormaker/download
 COMMAND=$1
 SYSTEM=$2
 
-DOWNLOAD_KAFKA=http://www.us.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz
+DOWNLOAD_KAFKA=http://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz
 DOWNLOAD_ZOOKEEPER=http://archive.apache.org/dist/zookeeper/zookeeper-3.4.3/zookeeper-3.4.3.tar.gz
 
 bootstrap() {


### PR DESCRIPTION
Old Kafka URL [http://www.us.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz](http://www.us.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz) resolves to "404 Not Found". Changed url to where Kafka_2.11-0.10.2.2 now resides