### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
           <configuration>
             <!-- Do not set argLine here, it will break the code coverage plugin.
                 Set it in the properties section. -->
-            <forkCount>1</forkCount>
+            <forkCount>1.5C</forkCount>
             <reuseForks>false</reuseForks>
             <!-- 30 minutes -->
             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
