### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 2.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <log4j.version>1.2.17</log4j.version>
     <jdk.version>1.8</jdk.version>
     <scala.version>2.11.12</scala.version>
-    <kafka.version>1.1.1</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
     <kafka.scala.version>2.11</kafka.scala.version>
     <helix.version>0.6.8</helix.version>
     <yammer.version>2.2.0</yammer.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 1.1.1
- [CVE-2021-38153](https://www.oscs1024.com/hd/CVE-2021-38153)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 1.1.1 to 2.8.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS